### PR TITLE
insert sort visualization can now take in the remaining Array and dis…

### DIFF
--- a/src/algorithms/insertionSort2.ts
+++ b/src/algorithms/insertionSort2.ts
@@ -1,5 +1,5 @@
 //we are passing in an array, sorting it, and returning a sorted copy of the array
-function insertionSort2(array: number[], lockedinarray?: number[], callback?: (arr: number[]) => any): number[] {
+function insertionSort2(array: number[], lockedinarray?: number[], callback?: (sortedArray: number[], remainingArray: number[]) => any): number[] {
     if (!lockedinarray) lockedinarray = [] // [1, 10, 5, 2]
     if (array.length == 0) return lockedinarray
     const newArray = structuredClone(array)
@@ -11,7 +11,7 @@ function insertionSort2(array: number[], lockedinarray?: number[], callback?: (a
     }
     // if it isn't less than any elements, it must be greater than all elements
     lockedinarray.splice(index, 0, valueToBeSorted)
-    if (callback) callback([...lockedinarray])
+    if (callback) callback(structuredClone(lockedinarray), structuredClone(array))
     return insertionSort2(newArray.slice(1), lockedinarray, callback)
 
 }

--- a/src/components/insertSortPage.tsx
+++ b/src/components/insertSortPage.tsx
@@ -2,13 +2,19 @@
 
 import insertionSort2 from "@/algorithms/insertionSort2";
 import { useEffect, useState } from "react";
+import { start } from "repl";
 
-type history = number[][]
+type snapshot = {
+    sortedArray: number[],
+    remainingArray: number[]
+}
+
+type History = snapshot[]
 
 //create starting array
 const startingArray = [5, 13, 9, 4, 12, 7, 1, 6, 8, 10, 2, 11, 3];
-const history = [structuredClone(startingArray)]
-const sortedHistory = insertionSort2(startingArray, [], (arr) => history.push(arr))
+const history: History = [{ sortedArray: [], remainingArray: structuredClone(startingArray) }]
+insertionSort2(startingArray, [], (sortedArray, remainingArray) => history.push({ sortedArray, remainingArray }))
 console.log(history)
 
 export function InsertionSort() {
@@ -36,10 +42,19 @@ export function InsertionSort() {
                 )
                 )}
             </div>
+            <label>SORTED ARRAY</label>
+            <div className="flex p-4">
+                {stepToShow.sortedArray.map((item, idx) => (
+                    <div key={idx}>
+                        <div className="mx-px p-3" style={{ height: `${item * 10}px`, width: '10px', background: 'green' }} />
+                    </div>
+                )
+                )}
+            </div>
             <div className="flex">
-                <label> Sorted Array </label>
+                <label> REMAINING ARRAY </label>
                 <div className="flex p-4">
-                    {stepToShow.map((item, idx) => (
+                    {stepToShow.remainingArray.map((item, idx) => (
                         <div key={idx}>
                             <div className="mx-px p-3" style={{ height: `${item * 10}px`, width: '10px', background: 'orange' }} />
                         </div>


### PR DESCRIPTION
…play it changing alongisde the sorted Array
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 816a294791ae4efa744ec1b2a95c787385305036  | 
|--------|--------|

### Summary:
Enhanced insertion sort visualization to display both sorted and remaining arrays during the sorting process.

**Key points**:
- Updated `src/algorithms/insertionSort2.ts` to modify the `insertionSort2` function.
  - The callback now receives both `sortedArray` and `remainingArray`.
  - Adjusted the callback invocation to pass `structuredClone` of both arrays.
- Updated `src/components/insertSortPage.tsx` to enhance the visualization.
  - Defined `snapshot` and `History` types to manage the sorted and remaining arrays.
  - Modified the `history` initialization and `insertionSort2` invocation to store snapshots.
  - Updated the `InsertionSort` component to display both sorted and remaining arrays.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->